### PR TITLE
RP-9: Remove image from blog problematicas cta.

### DIFF
--- a/modules/features/retopais_feature_pages/plugins/content_types/problematicas_cta.inc
+++ b/modules/features/retopais_feature_pages/plugins/content_types/problematicas_cta.inc
@@ -22,34 +22,17 @@ function problematicas_cta_render($subtype, $conf, $panel_args, $context) {
   $block = new stdClass();
   $block->title = '';
 
-  $block->content['problematicas-cta-title'] = array(
-    '#markup' => '<h3>' . check_plain(variable_get('retopais_feature_pages_blog_problematicas_cta_title', '')) . '</h3>',
+  $block->content['problematicas-cta-link'] = array(
+    '#theme' => 'link',
+    '#text' => check_plain(variable_get('retopais_feature_pages_blog_problematicas_cta_title', 'Descubrí las problemáticas')),
+    '#path' => 'problematicas',
+    '#prefix' => '<div class="problematicas-cta-link">',
+    '#suffix' => '</div>',
+    '#options' => array(
+      'attributes' => array(),
+      'html' => FALSE,
+    ),
   );
 
-  $image = file_load(variable_get('retopais_feature_pages_blog_problematicas_cta_image', 0));
-  if ($image) {
-    $image_path = $image->uri;
-
-    $variables = array(
-      'style_name' => RETOPAIS_FEATURE_PAGES_BLOG_PROBLEMATICAS_CTA_IMAGE,
-      'path' => $image_path,
-      'attributes' => array(),
-    );
-
-    $block->content['problematicas-cta-link'] = array(
-      '#theme' => 'link',
-      '#text' => theme_image_style($variables),
-      '#path' => 'problematicas',
-      '#prefix' => '<div class="problematicas-cta-link">',
-      '#suffix' => '</div>',
-      '#options' => array(
-        'attributes' => array(
-          'class' => array('problematicas-cta-link'),
-          'title' => t('Ir a página de Problemáticas'),
-        ),
-        'html' => TRUE,
-      ),
-    );
-  }
   return $block;
 }

--- a/modules/features/retopais_feature_pages/retopais_feature_pages.module
+++ b/modules/features/retopais_feature_pages/retopais_feature_pages.module
@@ -359,31 +359,7 @@ function retopais_feature_pages_blog_form($form, $form_state) {
     '#required' => TRUE,
   );
 
-  $form['retopais_feature_pages_blog_problematicas_cta_image'] = array(
-    '#type' => 'managed_file',
-    '#title' => t('Imagen del CTA de problemáticas'),
-    '#description' => t('Tipos de archivo permitidos: gif, png, jpg, jpeg'),
-    '#default_value' => variable_get('retopais_feature_pages_blog_problematicas_cta_image', 0),
-    '#upload_validators' => array(
-      'file_validate_extensions' => array('gif png jpg jpeg'),
-    ),
-    '#upload_location' => 'public://blog/',
-    '#required' => TRUE,
-  );
-
-  $form['#submit'][] = 'retopais_feature_pages_blog_form_submit';
-
   return system_settings_form($form);
-}
-
-/**
- * Submit form for problematicas form.
- */
-function retopais_feature_pages_blog_form_submit($form, &$form_state) {
-  $values = $form_state['values'];
-  $existing_image = variable_get('retopais_feature_pages_blog_problematicas_cta_image', 0);
-  $new_image = $values['retopais_feature_pages_blog_problematicas_cta_image'];
-  retopais_feature_pages_handle_file_submit($existing_image, $new_image);
 }
 
 /**


### PR DESCRIPTION
https://manati.atlassian.net/browse/RP-9

This PR removes the image from the problematicas CTA in sidebar.

How-to-test:
- Go to http://retopais.dev/admin/config/retopais/blog, you should only have a textfield
- Go to http://retopais.dev/blog, you should get a 'Descubrí las problemáticas' CTA
