### PR TITLE
Update Drupal core and contrib modules

### DIFF
--- a/drupal.make.yml
+++ b/drupal.make.yml
@@ -17,7 +17,7 @@ projects:
 
   # Projects.
   admin_menu:
-    version: "3.0-rc5"
+    version: "3.0-rc6"
   admin_views:
     version: "1.6"
   adminimal_admin_menu:

--- a/drupal.make.yml
+++ b/drupal.make.yml
@@ -48,7 +48,7 @@ projects:
   email:
     version: "1.3"
   entity:
-    version: "1.8"
+    version: "1.9"
   entityreference:
     version: "1.2"
   environment:

--- a/drupal.make.yml
+++ b/drupal.make.yml
@@ -42,7 +42,7 @@ projects:
   date:
     version: "2.10"
   devel:
-    version: "1.5"
+    version: "1.7"
   diff:
     version: "3.3"
   email:

--- a/drupal.make.yml
+++ b/drupal.make.yml
@@ -75,7 +75,7 @@ projects:
   libraries:
     version: "2.3"
   link:
-    version: "1.4"
+    version: "1.6"
   magic:
     version: "2.3"
   master:

--- a/drupal.make.yml
+++ b/drupal.make.yml
@@ -101,7 +101,7 @@ projects:
   paragraphs:
     version: "1.0-rc5"
   path_breadcrumbs:
-    version: "3.3"
+    version: "3.4"
   pathauto:
     version: "1.3"
   panels:

--- a/drupal.make.yml
+++ b/drupal.make.yml
@@ -117,7 +117,7 @@ projects:
   semantic_panels:
     version: "1.2"
   shs:
-    version: "1.6"
+    version: "1.8"
   smtp:
     version: "1.4"
   strongarm:

--- a/drupal.make.yml
+++ b/drupal.make.yml
@@ -113,7 +113,7 @@ projects:
   recaptcha:
     version: "2.2"
   select_or_other:
-    version: "2.22"
+    version: "2.24"
   semantic_panels:
     version: "1.2"
   shs:

--- a/drupal.make.yml
+++ b/drupal.make.yml
@@ -44,7 +44,7 @@ projects:
   devel:
     version: "1.7"
   diff:
-    version: "3.3"
+    version: "3.4"
   email:
     version: "1.3"
   entity:

--- a/drupal.make.yml
+++ b/drupal.make.yml
@@ -109,7 +109,7 @@ projects:
   panels_everywhere:
     version: "1.0-rc2"
   rabbit_hole:
-    version: "2.24"
+    version: "2.25"
   recaptcha:
     version: "2.2"
   select_or_other:

--- a/drupal.make.yml
+++ b/drupal.make.yml
@@ -21,7 +21,7 @@ projects:
   admin_views:
     version: "1.6"
   adminimal_admin_menu:
-    version: "1.7"
+    version: "1.9"
   aurora:
     version: "3.6"
     type: "theme"

--- a/drupal.make.yml
+++ b/drupal.make.yml
@@ -13,7 +13,7 @@ projects:
     download:
       type: "git"
       url: "https://github.com/pantheon-systems/drops-7.git"
-      tag: "7.54"
+      tag: "7.66"
 
   # Projects.
   admin_menu:

--- a/drupal.make.yml
+++ b/drupal.make.yml
@@ -26,7 +26,7 @@ projects:
     version: "3.6"
     type: "theme"
   captcha:
-    version: "1.4"
+    version: "1.5"
   ckeditor:
     version: "1.17"
   ckeditor_entity_embed:

--- a/drupal.make.yml
+++ b/drupal.make.yml
@@ -38,7 +38,7 @@ projects:
   chosen:
     version: "2.0-beta5"
   ctools:
-    version: "1.12"
+    version: "1.15"
   date:
     version: "2.10"
   devel:

--- a/drupal.make.yml
+++ b/drupal.make.yml
@@ -133,7 +133,7 @@ projects:
   video_embed_field:
     version: "2.0-beta11"
   views:
-    version: "3.16"
+    version: "3.22"
   views_bulk_operations:
     version: "3.4"
   views_cache_bully:

--- a/drupal.make.yml
+++ b/drupal.make.yml
@@ -135,7 +135,7 @@ projects:
   views:
     version: "3.22"
   views_bulk_operations:
-    version: "3.4"
+    version: "3.5"
   views_cache_bully:
     version: "3.1"
   views_data_export:

--- a/drupal.make.yml
+++ b/drupal.make.yml
@@ -88,7 +88,7 @@ projects:
   metatag:
     version: "1.21"
   module_filter:
-    version: "2.0"
+    version: "2.2"
   multistep:
     download:
       type: "git"

--- a/drupal.make.yml
+++ b/drupal.make.yml
@@ -50,7 +50,7 @@ projects:
   entity:
     version: "1.9"
   entityreference:
-    version: "1.2"
+    version: "1.5"
   environment:
     version: "1.0"
   environment_indicator:

--- a/modules/features/retopais_feature_config/retopais_feature_config.features.metatag.inc
+++ b/modules/features/retopais_feature_config/retopais_feature_config.features.metatag.inc
@@ -13,6 +13,7 @@ function retopais_feature_config_metatag_export_default() {
   // Exported Metatag config instance: global.
   $config['global'] = array(
     'instance' => 'global',
+    'disabled' => FALSE,
     'config' => array(
       'title' => array(
         'value' => '[current-page:title] | [current-page:pager][site:name]',
@@ -395,6 +396,7 @@ function retopais_feature_config_metatag_export_default() {
   // Exported Metatag config instance: global:frontpage.
   $config['global:frontpage'] = array(
     'instance' => 'global:frontpage',
+    'disabled' => FALSE,
     'config' => array(
       'title' => array(
         'value' => '[site:name]',

--- a/modules/features/retopais_feature_config/retopais_feature_config.strongarm.inc
+++ b/modules/features/retopais_feature_config/retopais_feature_config.strongarm.inc
@@ -275,14 +275,14 @@ function retopais_feature_config_strongarm() {
     'language' => 'es',
     'name' => 'Spanish',
     'native' => 'Español',
-    'direction' => 0,
-    'enabled' => 1,
-    'plurals' => 0,
+    'direction' => '0',
+    'enabled' => '1',
+    'plurals' => '0',
     'formula' => '',
     'domain' => '',
     'prefix' => 'es',
-    'weight' => 0,
-    'javascript' => '',
+    'weight' => '0',
+    'javascript' => 'TJCq9srd51b0zpYBm2qJBIP7mn_AUjDKhfUmJoI7Jmk',
   );
   $export['language_default'] = $strongarm;
 

--- a/modules/features/retopais_feature_proposals/retopais_feature_proposals.info
+++ b/modules/features/retopais_feature_proposals/retopais_feature_proposals.info
@@ -13,6 +13,7 @@ dependencies[] = image
 dependencies[] = link
 dependencies[] = list
 dependencies[] = multistep
+dependencies[] = node
 dependencies[] = number
 dependencies[] = options
 dependencies[] = page_manager

--- a/modules/features/retopais_feature_proposals/retopais_feature_proposals.views_default.inc
+++ b/modules/features/retopais_feature_proposals/retopais_feature_proposals.views_default.inc
@@ -23,11 +23,20 @@ function retopais_feature_proposals_views_default_views() {
   /* Display: Master */
   $handler = $view->new_display('default', 'Master', 'default');
   $handler->display->display_options['use_more_always'] = FALSE;
+  $handler->display->display_options['use_more_text'] = 'más';
   $handler->display->display_options['access']['type'] = 'perm';
   $handler->display->display_options['cache']['type'] = 'none';
   $handler->display->display_options['query']['type'] = 'views_query';
   $handler->display->display_options['exposed_form']['type'] = 'basic';
+  $handler->display->display_options['exposed_form']['options']['reset_button_label'] = 'Reiniciar';
   $handler->display->display_options['pager']['type'] = 'full';
+  $handler->display->display_options['pager']['options']['expose']['items_per_page_label'] = 'elementos por página';
+  $handler->display->display_options['pager']['options']['expose']['items_per_page_options_all_label'] = '— Todo(s) —';
+  $handler->display->display_options['pager']['options']['expose']['offset_label'] = 'Desplazamiento';
+  $handler->display->display_options['pager']['options']['tags']['first'] = '« primero';
+  $handler->display->display_options['pager']['options']['tags']['previous'] = '‹ anterior';
+  $handler->display->display_options['pager']['options']['tags']['next'] = 'siguiente ›';
+  $handler->display->display_options['pager']['options']['tags']['last'] = 'última »';
   $handler->display->display_options['style_plugin'] = 'default';
   $handler->display->display_options['row_plugin'] = 'fields';
   /* Relationship: Entity Reference: Referenced Entity */
@@ -762,6 +771,7 @@ function retopais_feature_proposals_views_default_views() {
   $handler = $view->new_display('default', 'Master', 'default');
   $handler->display->display_options['title'] = 'Propuestas';
   $handler->display->display_options['use_more_always'] = FALSE;
+  $handler->display->display_options['use_more_text'] = 'más';
   $handler->display->display_options['access']['type'] = 'perm';
   $handler->display->display_options['access']['perm'] = 'view proposals';
   $handler->display->display_options['cache']['type'] = 'none';
@@ -769,6 +779,7 @@ function retopais_feature_proposals_views_default_views() {
   $handler->display->display_options['exposed_form']['type'] = 'basic';
   $handler->display->display_options['exposed_form']['options']['submit_button'] = 'Aplicar';
   $handler->display->display_options['exposed_form']['options']['reset_button'] = TRUE;
+  $handler->display->display_options['exposed_form']['options']['reset_button_label'] = 'Reiniciar';
   $handler->display->display_options['exposed_form']['options']['exposed_sorts_label'] = 'Ordenar por';
   $handler->display->display_options['exposed_form']['options']['expose_sort_order'] = FALSE;
   $handler->display->display_options['exposed_form']['options']['autosubmit'] = TRUE;


### PR DESCRIPTION
**Description:**

- Update changes that are not stored in the features.
- Update Drupal Core from 7.54 to 7.66
- Update contrib module: Administration menu 7.x-3.0-rc5 to Administration menu 7.x-3.0-rc6
- Update contrib module from: Adminimal Administration Menu 7.x-1.7 to Adminimal Administration Menu 7.x-1.9
- Update contrib module from: CAPTCHA 7.x-1.4 to CAPTCHA 7.x-1.5
- Update contrib module from: Chaos Tool Suite (ctools) 7.x-1.12 to Chaos Tool Suite (ctools) 7.x-1.15
- Update contrib module from: Devel 7.x-1.5 to Devel 7.x-1.7
- Update contrib module from: Diff 7.x-3.3 to Diff 7.x-3.3
- Update contrib module from: Entity API 7.x-1.8 to Entity API 7.x-1.9
- Update contrib module from: Entity reference 7.x-1.2 to Entity reference 7.x-1.5
- Update contrib module from: Link 7.x-1.4 to Link 7.x-1.6
- Update contrib module from: Module Filter 7.x-2.0 to Module Filter 7.x-2.2
- Update contrib module from: Path Breadcrumbs 7.x-3.3 to Path Breadcrumbs 7.x-3.4
- Update contrib module from: Rabbit Hole 7.x-2.24 to Rabbit Hole 7.x-2.25
- Update contrib module from: Views 7.x-3.16 to Views 7.x-3.22
- Update contrib module from: Views Bulk Operations (VBO) 7.x-3.4 to Views Bulk Operations (VBO) 7.x-3.5
- Update contrib module from: Select (or other) 7.x-2.22 to Select (or other) 7.x-2.24
- Update contrib module from: Simple hierarchical select 7.x-1.6 to Simple hierarchical select 7.x-1.8

**Steps to test:**

- [ ] Run the command: `ahoy up`
- [ ] Run the command: `./node_modules/.bin/aquifer build && ahoy drush updb -y && ahoy drush cc all`
- [ ] Check that the views and contents are displayed correctly.