### PR TITLE
Add new features to complete the design

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ In order to run behat tests; you should execute:
 ahoy site behat
 ```
 
+### Special options
+
+The site has a form for users to send their proposals, but this form will be available for a certain time. To activate or deactivate this form, you must enter the permissions configuration page: Users -> Permissions
+
+```bash
+admin/people/permissions
+```
+
+Add or delete the permission: "Proposal: Create new content" to the role you want, according to your needs.
+
 ### Build Environment
 
 To build this environment you need recent docker compose and docker versions.

--- a/modules/features/retopais_feature_blog/retopais_feature_blog.info
+++ b/modules/features/retopais_feature_blog/retopais_feature_blog.info
@@ -8,6 +8,7 @@ dependencies[] = entityreference
 dependencies[] = features
 dependencies[] = image
 dependencies[] = inline_entity_form
+dependencies[] = node
 dependencies[] = options
 dependencies[] = page_manager
 dependencies[] = path_breadcrumbs

--- a/modules/features/retopais_feature_blog/retopais_feature_blog.views_default.inc
+++ b/modules/features/retopais_feature_blog/retopais_feature_blog.views_default.inc
@@ -164,7 +164,7 @@ function retopais_feature_blog_views_default_views() {
   $handler->display->display_options['title'] = 'Últimos artículos';
   $handler->display->display_options['defaults']['pager'] = FALSE;
   $handler->display->display_options['pager']['type'] = 'some';
-  $handler->display->display_options['pager']['options']['items_per_page'] = '3';
+  $handler->display->display_options['pager']['options']['items_per_page'] = '2';
   $handler->display->display_options['pager']['options']['offset'] = '0';
   $handler->display->display_options['defaults']['header'] = FALSE;
   $handler->display->display_options['defaults']['relationships'] = FALSE;

--- a/modules/features/retopais_feature_pages/plugins/content_types/contact_media_kit.inc
+++ b/modules/features/retopais_feature_pages/plugins/content_types/contact_media_kit.inc
@@ -20,28 +20,40 @@ $plugin = array(
 function media_kit_render($subtype, $conf, $panel_args, $context) {
   // Build the content type block.
   $block = new stdClass();
-  $block->title = t('Descargar Media Kit');
 
   $image = file_load(variable_get('retopais_feature_pages_contacto_media_kit_image', 0));
   $file = file_load(variable_get('retopais_feature_pages_contacto_media_kit_file', 0));
-  if ($image && $file) {
-    $file_path = file_create_url($file->uri);
-    $image_path = $image->uri;
 
-    $variables = array(
-      'path' => $image_path,
-      'attributes' => array(),
-    );
+  if ($file) {
+    $file_path = file_create_url($file->uri);
+
+    if ($image) {
+      $variables = array(
+        'path' => $image->uri,
+        'alt' => t('Descargar Media Kit'),
+        'title' => t('Descargar Media Kit'),
+        'attributes' => array(),
+      );
+
+      $block->title = t('Descargar Media Kit');
+      $text = theme_image($variables);
+      $classes = array('media-kit-download-link');
+    }
+    else {
+      $block->title = '';
+      $text = t('Descargar Media Kit');
+      $classes = array('button', 'parallelogram');
+    }
 
     $block->content['media-kit'] = array(
       '#theme' => 'link',
-      '#text' => theme_image($variables),
+      '#text' => $text,
       '#path' => $file_path,
       '#prefix' => '<div class="media-kit-download">',
       '#suffix' => '</div>',
       '#options' => array(
         'attributes' => array(
-          'class' => array('media-kit-download-link'),
+          'class' => $classes,
           'title' => t('Descargar Media Kit'),
         ),
         'html' => TRUE,

--- a/modules/features/retopais_feature_pages/plugins/content_types/homepage_que_es_reto_pais.inc
+++ b/modules/features/retopais_feature_pages/plugins/content_types/homepage_que_es_reto_pais.inc
@@ -41,6 +41,7 @@ function homepage_que_es_reto_pais_render($subtype, $conf, $panel_args, $context
   // Get image or video.
   $video = variable_get('retopais_feature_pages_homepage_que_es_reto_pais_video', '');
   $image = variable_get('retopais_feature_pages_homepage_que_es_reto_pais_image', 0);
+
   if ($video) {
     $parts = drupal_parse_url($video);
     if (isset($parts['query'])) {
@@ -50,13 +51,18 @@ function homepage_que_es_reto_pais_render($subtype, $conf, $panel_args, $context
   }
   elseif ($image) {
     $image_file = file_load($image);
-    $image_path = $image_file->uri;
-    $variables = array(
-      'path' => $image_path,
-      'attributes' => array(),
-    );
+    if ($image_file) {
+      $image_path = $image_file->uri;
+      $variables = array(
+        'path' => $image_path,
+        'attributes' => array(),
+      );
 
-    $image = theme_image($variables);
+      $image = theme_image($variables);
+    }
+    else {
+      $image = NULL;
+    }
   }
 
   $block->content['que-es-reto-pais'] = array(
@@ -67,5 +73,6 @@ function homepage_que_es_reto_pais_render($subtype, $conf, $panel_args, $context
     '#title' => $title,
     '#text' => $text,
   );
+
   return $block;
 }

--- a/modules/features/retopais_feature_pages/plugins/content_types/homepage_timeline.inc
+++ b/modules/features/retopais_feature_pages/plugins/content_types/homepage_timeline.inc
@@ -23,14 +23,31 @@ function homepage_timeline_render($subtype, $conf, $panel_args, $context) {
   $block->title = '';
 
   $image = file_load(variable_get('retopais_feature_pages_homepage_timeline_image', 0));
-  if ($image) {
-    $image_path = $image->uri;
+  $image_mobile = file_load(variable_get('retopais_feature_pages_homepage_timeline_image_mobile', 0));
 
+  if ($image) {
     $block->content['timeline-image'] = array(
       '#theme' => 'image',
-      '#path' => $image_path,
-      '#attributes' => array(),
+      '#path' => $image->uri,
+      '#alt' => t('Fechas importantes'),
+      '#title' => t('Fechas importantes'),
+      '#attributes' => array(
+        'class' => array('timeline-image-desktop'),
+      ),
     );
   }
+
+  if ($image_mobile) {
+    $block->content['timeline-image-mobile'] = array(
+      '#theme' => 'image',
+      '#path' => $image_mobile->uri,
+      '#alt' => t('Fechas importantes'),
+      '#title' => t('Fechas importantes'),
+      '#attributes' => array(
+        'class' => array('timeline-image-mobile'),
+      ),
+    );
+  }
+
   return $block;
 }

--- a/modules/features/retopais_feature_pages/retopais_feature_pages.module
+++ b/modules/features/retopais_feature_pages/retopais_feature_pages.module
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Code for the Reto Pais Pages feature.
@@ -243,7 +244,6 @@ function retopais_feature_pages_contacto_form($form, $form_state) {
       'file_validate_extensions' => array('gif png jpg jpeg'),
     ),
     '#upload_location' => 'public://contact/',
-    '#required' => TRUE,
   );
 
   $form['retopais_feature_pages_contacto_media_kit_file'] = array(
@@ -289,9 +289,11 @@ function retopais_feature_pages_handle_file_submit($existing_fid, $new_fid) {
   }
   if (!$existing_fid || $existing_fid !== $new_fid) {
     $new_file = file_load($new_fid);
-    $new_file->status = FILE_STATUS_PERMANENT;
-    file_save($new_file);
-    file_usage_add($new_file, 'retopais_feature_pages', 'contact_page', 1);
+    if ($new_file) {
+      $new_file->status = FILE_STATUS_PERMANENT;
+      file_save($new_file);
+      file_usage_add($new_file, 'retopais_feature_pages', 'contact_page', 1);
+    }
   }
 }
 
@@ -470,6 +472,16 @@ function retopais_feature_pages_homepage_form($form, $form_state) {
     '#required' => TRUE,
   );
 
+  $form['retopais_feature_pages_homepage_timeline_image_mobile'] = array(
+    '#type' => 'managed_file',
+    '#title' => t('Imagen del timeline móvil'),
+    '#default_value' => variable_get('retopais_feature_pages_homepage_timeline_image_mobile', 0),
+    '#upload_validators' => array(
+      'file_validate_extensions' => array('gif png jpg jpeg'),
+    ),
+    '#upload_location' => 'public://homepage/',
+  );
+
   $form['#submit'][] = 'retopais_feature_pages_homepage_form_submit';
 
   return system_settings_form($form);
@@ -480,9 +492,15 @@ function retopais_feature_pages_homepage_form($form, $form_state) {
  */
 function retopais_feature_pages_homepage_form_submit($form, &$form_state) {
   $values = $form_state['values'];
+  // Save timeline image desktop.
   $existing_image = variable_get('retopais_feature_pages_homepage_timeline_image', 0);
   $new_image = $values['retopais_feature_pages_homepage_timeline_image'];
   retopais_feature_pages_handle_file_submit($existing_image, $new_image);
+  // Save timeline image mobile.
+  $existing_image = variable_get('retopais_feature_pages_homepage_timeline_image_mobile', 0);
+  $new_image = $values['retopais_feature_pages_homepage_timeline_image_mobile'];
+  retopais_feature_pages_handle_file_submit($existing_image, $new_image);
+  // Save "what is" image.
   $existing_image = variable_get('retopais_feature_pages_homepage_que_es_reto_pais_image', 0);
   $new_image = $values['retopais_feature_pages_homepage_que_es_reto_pais_image'];
   retopais_feature_pages_handle_file_submit($existing_image, $new_image);

--- a/modules/features/retopais_feature_pages/theme/homepage-que-es-reto-pais.tpl.php
+++ b/modules/features/retopais_feature_pages/theme/homepage-que-es-reto-pais.tpl.php
@@ -6,25 +6,37 @@
 ?>
 <div class="que-es-reto-pais--container">
   <div class="que-es-reto-pais--container-inner">
-    <div class="que-es-reto-pais--left">
-      <h2 class="que-es-reto-pais--title"><?php print $title; ?></h2>
-      <p class="que-es-reto-pais--description">
-        <?php print $text; ?>
-      </p>
-      <?php if ($link): ?>
-      <div class="que-es-reto-pais--link"><?php print $link; ?></div>
-      <?php endif; ?>
-    </div>
-    <div class="que-es-reto-pais--right">
-      <?php if ($video): ?>
-        <div class="que-es-reto-pais--video">
-          <iframe width="560" height="315" src="<?php print $video; ?>" frameborder="0"></iframe>
-        </div>
-      <?php elseif ($image): ?>
-        <div class="que-es-reto-pais--image">
-          <?php print $image; ?>
-        </div>
-      <?php endif; ?>
-    </div>
+    <?php if ($video || $image): ?>
+      <div class="que-es-reto-pais--left">
+        <h2 class="que-es-reto-pais--title"><?php print $title; ?></h2>
+        <p class="que-es-reto-pais--description">
+          <?php print $text; ?>
+        </p>
+        <?php if ($link): ?>
+        <div class="que-es-reto-pais--link"><?php print $link; ?></div>
+        <?php endif; ?>
+      </div>
+      <div class="que-es-reto-pais--right">
+        <?php if ($video): ?>
+          <div class="que-es-reto-pais--video">
+            <iframe width="560" height="315" src="<?php print $video; ?>" frameborder="0"></iframe>
+          </div>
+        <?php elseif ($image): ?>
+          <div class="que-es-reto-pais--image">
+            <?php print $image; ?>
+          </div>
+        <?php endif; ?>
+      </div>
+    <?php else: ?>
+      <div class="que-es-reto-pais--full">
+        <h2 class="que-es-reto-pais--title"><?php print $title; ?></h2>
+        <p class="que-es-reto-pais--description">
+          <?php print $text; ?>
+        </p>
+        <?php if ($link): ?>
+        <div class="que-es-reto-pais--link"><?php print $link; ?></div>
+        <?php endif; ?>
+      </div>
+    <?php endif; ?>
   </div>
 </div>


### PR DESCRIPTION
### Description

- Add to the Readme file, the instructions for enabling and disabling the proposal form.
- Add to the home configuration form the option to add an image in the field important dates for mobile display.
- Change the news block of the footer so that it only shows two publications.
- Change the display of the sidebar in the contact form, but the image is not eliminated, rather, a condition is created, if in the configuration of the contact form there is an image, the image is shown in the sidebar, but if there is no image configured, a button is displayed to download the kit.
- In the block "We present the finalists!", It is configured to detect, if there is an image, two contiguous blocks are shown, otherwise, only a single block with text is shown.

### Steps to test:

- [ ] Run the command: `ahoy drush fra -y && ahoy drush cc all`.
- [ ] Go to the page: `admin/config/retopais/homepage` and delete the image on field: "Imagen del componente Qué es Reto País", then add the image to field "Imagen del timeline móvil".
- [ ] Go to the page: `admin/config/retopais/contacto` and delete the image on field: "Imagen del Media Kit".
- [ ] Go to the homepage and checks that the display is as expected.
- [ ] Go to the contact form: `contacto` and checks that the display is as expected.