### PR TITLE
- Add custom wrapper for each button on proposal form.

### DIFF
--- a/modules/features/retopais_feature_proposals/retopais_feature_proposals.module
+++ b/modules/features/retopais_feature_proposals/retopais_feature_proposals.module
@@ -127,6 +127,22 @@ function retopais_feature_proposals_form_proposal_node_form_alter(&$form, $form_
     $form['path']['#access'] = FALSE;
     $form['field_juez_asignado']['#access'] = FALSE;
   }
+
+  // Add custom wrapper for each button.
+  if (isset($form['actions']['previous'])) {
+    $form['actions']['previous']['#prefix'] = '<div cass="form-previous" id="edit-actions-previous">';
+    $form['actions']['previous']['#suffix'] = '</div>';
+  }
+
+  if (isset($form['actions']['next'])) {
+    $form['actions']['next']['#prefix'] = '<div cass="form-next" id="edit-actions-next">';
+    $form['actions']['next']['#suffix'] = '</div>';
+  }
+
+  if (isset($form['actions']['done'])) {
+    $form['actions']['done']['#prefix'] = '<div cass="form-done" id="edit-actions-done">';
+    $form['actions']['done']['#suffix'] = '</div>';
+  }
 }
 
 /**


### PR DESCRIPTION
### Description:

Add custom wrapper for each button on proposal form.

### Steps to tests:

Run the command: `ahoy drush fra -y && ahoy drush cc all`.
Go to the page: `propone-idea` and checks that each buttons have a custom wrapper.