### PR TITLE
Add field to export proposal view

### DIFF
--- a/drupal.make.yml
+++ b/drupal.make.yml
@@ -13,7 +13,7 @@ projects:
     download:
       type: "git"
       url: "https://github.com/pantheon-systems/drops-7.git"
-      tag: "7.66"
+      tag: "7.67"
 
   # Projects.
   admin_menu:

--- a/drupal.make.yml
+++ b/drupal.make.yml
@@ -119,7 +119,7 @@ projects:
   shs:
     version: "1.8"
   smtp:
-    version: "1.4"
+    version: "1.7"
   strongarm:
     version: "2.0"
   styleguide:

--- a/modules/features/retopais_feature_proposals/retopais_feature_proposals.views_default.inc
+++ b/modules/features/retopais_feature_proposals/retopais_feature_proposals.views_default.inc
@@ -710,6 +710,16 @@ function retopais_feature_proposals_views_default_views() {
   $handler->display->display_options['fields']['field_project_running']['field'] = 'field_project_running';
   $handler->display->display_options['fields']['field_project_running']['alter']['trim_whitespace'] = TRUE;
   $handler->display->display_options['fields']['field_project_running']['alter']['strip_tags'] = TRUE;
+  /* Campo: Contenido: ¿Te gustaría compartir tu idea como parte de la campaña 1820 ideas y participar por premios adicionales? */
+  $handler->display->display_options['fields']['field_share_idea_with_sponsors']['id'] = 'field_share_idea_with_sponsors';
+  $handler->display->display_options['fields']['field_share_idea_with_sponsors']['table'] = 'field_data_field_share_idea_with_sponsors';
+  $handler->display->display_options['fields']['field_share_idea_with_sponsors']['field'] = 'field_share_idea_with_sponsors';
+  $handler->display->display_options['fields']['field_share_idea_with_sponsors']['label'] = 'Compartir idea con patrocinadores';
+  $handler->display->display_options['fields']['field_share_idea_with_sponsors']['element_type'] = '0';
+  $handler->display->display_options['fields']['field_share_idea_with_sponsors']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['field_share_idea_with_sponsors']['element_wrapper_type'] = '0';
+  $handler->display->display_options['fields']['field_share_idea_with_sponsors']['element_default_classes'] = FALSE;
+  $handler->display->display_options['fields']['field_share_idea_with_sponsors']['field_api_classes'] = TRUE;
   /* Sort criterion: Content: Post date */
   $handler->display->display_options['sorts']['created']['id'] = 'created';
   $handler->display->display_options['sorts']['created']['table'] = 'node';
@@ -869,6 +879,7 @@ function retopais_feature_proposals_views_default_views() {
     t('¿Qué te motivó a proponer esta idea o a emprender en este tema?'),
     t('¿Qué tipo de solución querés proponer?'),
     t('¿Se encuentra en ejecución?'),
+    t('Compartir idea con patrocinadores'),
     t('Fecha de mensaje'),
     t('Data export'),
     t('Compartir con patrocinadores'),


### PR DESCRIPTION
### [OPS-505](https://manati.atlassian.net/browse/OPS-505)

**Description:**

- Add column "Share the idea with the sponsors" to the view: `export proposal`.

**Steps to test:**

- [ ] Run the command: `ahoy drush fra -y && ahoy drush cc all`.
- [ ] Open the page: `http://ops505a-retopais.pantheonsite.io/admin/propuestas/exportar-propuestas`, the site download a CSV file, open this file and check that there is a column called: "Share the idea with the sponsors".
- [ ] Open the page: `http://ops505a-retopais.pantheonsite.io/admin/propuestas/exportar-propuestas/compartir-con-patrocinadores`, the site download a CSV file, open this file and check that there is a column called: "Share the idea with the sponsors".


**Multidev:** http://ops505a-retopais.pantheonsite.io ( retopais / retopais2019 )