### PR TITLE
Add description to proposal export CSV

### DIFF
--- a/modules/features/retopais_feature_proposals/retopais_feature_proposals.views_default.inc
+++ b/modules/features/retopais_feature_proposals/retopais_feature_proposals.views_default.inc
@@ -378,12 +378,24 @@ function retopais_feature_proposals_views_default_views() {
   $handler->display->display_options['fields']['title']['alter']['ellipsis'] = FALSE;
   $handler->display->display_options['fields']['title']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['title']['link_to_node'] = FALSE;
+  /* Campo: Contenido: ¿Qué problemática deseás solucionar? */
+  $handler->display->display_options['fields']['field_problem_to_solve']['id'] = 'field_problem_to_solve';
+  $handler->display->display_options['fields']['field_problem_to_solve']['table'] = 'field_data_field_problem_to_solve';
+  $handler->display->display_options['fields']['field_problem_to_solve']['field'] = 'field_problem_to_solve';
+  $handler->display->display_options['fields']['field_problem_to_solve']['label'] = 'Problemática a resolver';
+  $handler->display->display_options['fields']['field_problem_to_solve']['element_type'] = '0';
+  $handler->display->display_options['fields']['field_problem_to_solve']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['field_problem_to_solve']['element_wrapper_type'] = '0';
+  $handler->display->display_options['fields']['field_problem_to_solve']['element_default_classes'] = FALSE;
+  $handler->display->display_options['fields']['field_problem_to_solve']['settings'] = array(
+    'bypass_access' => 0,
+    'link' => 0,
+  );
+  $handler->display->display_options['fields']['field_problem_to_solve']['field_api_classes'] = TRUE;
   /* Field: Content: Contanos de manera resumida de qué se trata tu idea y cómo resolverá la problemática */
   $handler->display->display_options['fields']['body']['id'] = 'body';
   $handler->display->display_options['fields']['body']['table'] = 'field_data_body';
   $handler->display->display_options['fields']['body']['field'] = 'body';
-  $handler->display->display_options['fields']['body']['label'] = '';
-  $handler->display->display_options['fields']['body']['exclude'] = TRUE;
   $handler->display->display_options['fields']['body']['alter']['trim_whitespace'] = TRUE;
   $handler->display->display_options['fields']['body']['alter']['strip_tags'] = TRUE;
   $handler->display->display_options['fields']['body']['element_type'] = '0';
@@ -392,22 +404,6 @@ function retopais_feature_proposals_views_default_views() {
   $handler->display->display_options['fields']['body']['element_default_classes'] = FALSE;
   $handler->display->display_options['fields']['body']['type'] = 'text_plain';
   $handler->display->display_options['fields']['body']['field_api_classes'] = TRUE;
-/* Campo: Contenido: ¿Qué problemática deseás solucionar? */
-  $handler->display->display_options['fields']['field_problem_to_solve']['id'] = 'field_problem_to_solve';
-  $handler->display->display_options['fields']['field_problem_to_solve']['table'] = 'field_data_field_problem_to_solve';
-  $handler->display->display_options['fields']['field_problem_to_solve']['field'] = 'field_problem_to_solve';
-  $handler->display->display_options['fields']['field_problem_to_solve']['label'] = 'Contanos de manera resumida de qué se trata tu idea y cómo resolverá la problemática';
-  $handler->display->display_options['fields']['field_problem_to_solve']['element_type'] = '0';
-  $handler->display->display_options['fields']['field_problem_to_solve']['element_label_colon'] = FALSE;
-  $handler->display->display_options['fields']['field_problem_to_solve']['element_wrapper_type'] = '0';
-  $handler->display->display_options['fields']['field_problem_to_solve']['element_default_classes'] = FALSE;
-  $handler->display->display_options['fields']['field_problem_to_solve']['type'] = 'entityreference_entity_view';
-  $handler->display->display_options['fields']['field_problem_to_solve']['settings'] = array(
-    'view_mode' => 'default',
-    'links' => 0,
-    'use_content_language' => 0,
-  );
-  $handler->display->display_options['fields']['field_problem_to_solve']['field_api_classes'] = TRUE;
   /* Field: Content: Correo electrónico */
   $handler->display->display_options['fields']['field_representative_email']['id'] = 'field_representative_email';
   $handler->display->display_options['fields']['field_representative_email']['table'] = 'field_data_field_representative_email';
@@ -853,6 +849,7 @@ function retopais_feature_proposals_views_default_views() {
     t('última »'),
     t('flag'),
     t('Nombre de la solución'),
+    t('Problemática a resolver'),
     t('Contanos de manera resumida de qué se trata tu idea y cómo resolverá la problemática'),
     t('Correo electrónico del representante'),
     t('Correo electrónico del responsable del proyecto'),


### PR DESCRIPTION
### [OPS-512](https://manati.atlassian.net/browse/OPS-512)

**Description:**

- The description field was excluded from the presentation, therefore, the change is made, so that the field is shown in the view.
- The field of the category was configured to show the whole entity represented, a change is made, so that it only shows the title of the category.

**Steps to test:**

- [ ] Run the command: `ahoy drush fra -y && ahoy drush cc all`.
- [ ] Within the administrative menu, go to the option: `Export proposals -> All proposals`.
- [ ] A CSV file will be downloaded, check that the title of the proposal is shown in the first column, the category of the proposal in the second column and the description of the proposal in the third column.

_Para probar esto, puede utilizar el siguiente multidev: `http://ops512f-retopais.pantheonsite.io`
Credenciales: `retopais / retopais2019`_